### PR TITLE
fix(ci): use backend/go.mod path in setup-go action

### DIFF
--- a/.github/workflows/test-backend.yml
+++ b/.github/workflows/test-backend.yml
@@ -20,8 +20,8 @@ jobs:
       - uses: actions/checkout@v4
       - uses: actions/setup-go@v5
         with:
-          go-version-file: go.mod
-          cache-dependency-path: go.sum
+          go-version-file: backend/go.mod
+          cache-dependency-path: backend/go.sum
       - run: go vet ./...
       - run: go test ./...
       - run: CGO_ENABLED=0 GOOS=linux go build -o /dev/null ./cmd/api


### PR DESCRIPTION
The `go-version-file` and `cache-dependency-path` inputs in `actions/setup-go` are relative to the workspace root, not the job's `working-directory`. Fixes the Test Backend workflow failure on main and develop.