### PR TITLE
feat(ios): real-device testing via rescience.com subdomains

### DIFF
--- a/ios/KickWatch/Sources/Services/APIClient.swift
+++ b/ios/KickWatch/Sources/Services/APIClient.swift
@@ -90,9 +90,9 @@ actor APIClient {
 
     init(baseURL: String? = nil) {
         #if DEBUG
-        self.baseURL = baseURL ?? "http://localhost:8080"
+        self.baseURL = baseURL ?? "https://api-dev.kickwatch.rescience.com"
         #else
-        self.baseURL = baseURL ?? "https://api.kickwatch.app"
+        self.baseURL = baseURL ?? "https://api.kickwatch.rescience.com"
         #endif
         let config = URLSessionConfiguration.default
         config.timeoutIntervalForRequest = 30

--- a/ios/KickWatch/Sources/Views/CampaignRowView.swift
+++ b/ios/KickWatch/Sources/Views/CampaignRowView.swift
@@ -1,4 +1,5 @@
 import SwiftUI
+import SwiftData
 
 struct CampaignRowView: View {
     let campaign: CampaignDTO

--- a/ios/KickWatch/Sources/Views/DiscoverView.swift
+++ b/ios/KickWatch/Sources/Views/DiscoverView.swift
@@ -30,9 +30,9 @@ struct DiscoverView: View {
     private var sortPicker: some View {
         Picker("Sort", selection: Binding(
             get: { vm.selectedSort },
-            set: { Task { await vm.selectSort($0) } }
+            set: { newSort in Task { await vm.selectSort(newSort) } }
         )) {
-            ForEach(sortOptions, id: \.0) { Text($1).tag($0) }
+            ForEach(sortOptions, id: \.0) { key, label in Text(label).tag(key) }
         }
         .pickerStyle(.segmented)
         .padding(.horizontal)


### PR DESCRIPTION
## Summary

Sets up AWS infrastructure and updates the iOS app for real-device testing.

### AWS Infrastructure (already provisioned)
- ACM wildcard certificate: `*.kickwatch.rescience.com`
- Dev ALB: `kickwatch-alb-dev` → `kickwatch-api-dev-tg` (port 8080, health `/api/health`)
- Prod ALB: `kickwatch-alb` → `kickwatch-api-tg`
- Both ALBs: HTTP→HTTPS redirect, HTTPS listener with ACM cert
- ECS services recreated with ALB target group bindings
- Cloudflare DNS: `api-dev.kickwatch.rescience.com` and `api.kickwatch.rescience.com` CNAME → respective ALBs

### iOS Changes
- `APIClient.swift`: DEBUG → `https://api-dev.kickwatch.rescience.com`, Release → `https://api.kickwatch.rescience.com`
- `CampaignRowView.swift`: add missing `import SwiftData`
- `DiscoverView.swift`: fix ambiguous `$0` in nested `Task` closure (Swift 5.9+ regression)