### PR TITLE
feat: investor metrics — velocity, momentum alerts, startup crawl

### DIFF
--- a/.github/workflows/deploy-backend.yml
+++ b/.github/workflows/deploy-backend.yml
@@ -112,6 +112,7 @@ jobs:
           echo "apns_team_id_arn=$(get_arn ${SECRET_PREFIX}/apns-team-id)"  >> $GITHUB_OUTPUT
           echo "apns_bundle_id_arn=$(get_arn ${SECRET_PREFIX}/apns-bundle-id)" >> $GITHUB_OUTPUT
           echo "apns_key_arn=$(get_arn ${SECRET_PREFIX}/apns-key)"      >> $GITHUB_OUTPUT
+          echo "webshare_proxy_url_arn=$(get_arn ${SECRET_PREFIX}/webshare-proxy-url)" >> $GITHUB_OUTPUT
 
       - name: Generate ECS task definition
         env:
@@ -141,11 +142,12 @@ jobs:
                   { "name": "APNS_ENV", "value": "${{ env.IS_PROD == 'true' && 'production' || 'sandbox' }}" }
                 ],
                 "secrets": [
-                  { "name": "DATABASE_URL",   "valueFrom": "${{ steps.secrets.outputs.db_arn }}" },
-                  { "name": "APNS_KEY_ID",    "valueFrom": "${{ steps.secrets.outputs.apns_key_id_arn }}" },
-                  { "name": "APNS_TEAM_ID",   "valueFrom": "${{ steps.secrets.outputs.apns_team_id_arn }}" },
-                  { "name": "APNS_BUNDLE_ID", "valueFrom": "${{ steps.secrets.outputs.apns_bundle_id_arn }}" },
-                  { "name": "APNS_KEY",       "valueFrom": "${{ steps.secrets.outputs.apns_key_arn }}" }
+                  { "name": "DATABASE_URL",        "valueFrom": "${{ steps.secrets.outputs.db_arn }}" },
+                  { "name": "APNS_KEY_ID",         "valueFrom": "${{ steps.secrets.outputs.apns_key_id_arn }}" },
+                  { "name": "APNS_TEAM_ID",        "valueFrom": "${{ steps.secrets.outputs.apns_team_id_arn }}" },
+                  { "name": "APNS_BUNDLE_ID",      "valueFrom": "${{ steps.secrets.outputs.apns_bundle_id_arn }}" },
+                  { "name": "APNS_KEY",            "valueFrom": "${{ steps.secrets.outputs.apns_key_arn }}" },
+                  { "name": "WEBSHARE_PROXY_URL",  "valueFrom": "${{ steps.secrets.outputs.webshare_proxy_url_arn }}" }
                 ],
                 "readonlyRootFilesystem": true,
                 "linuxParameters": { "initProcessEnabled": true },

--- a/backend/.env.example
+++ b/backend/.env.example
@@ -1,6 +1,11 @@
 DATABASE_URL=postgres://user:password@localhost:5432/kickwatch?sslmode=disable
 PORT=8080
 
+# Webshare rotating residential proxy - bypasses Cloudflare on server-side Kickstarter requests
+# Format: http://username:password@p.webshare.io:80
+# Leave empty to disable proxy (direct connection)
+WEBSHARE_PROXY_URL=
+
 APNS_KEY_ID=YOUR_KEY_ID
 APNS_TEAM_ID=YOUR_TEAM_ID
 APNS_BUNDLE_ID=com.yourname.kickwatch

--- a/backend/cmd/api/main.go
+++ b/backend/cmd/api/main.go
@@ -26,8 +26,8 @@ func main() {
 		log.Println("DATABASE_URL not set, running without database")
 	}
 
-	graphClient := service.NewKickstarterGraphClient()
-	restClient := service.NewKickstarterRESTClient()
+	graphClient := service.NewKickstarterGraphClient(cfg.ProxyURL)
+	restClient := service.NewKickstarterRESTClient(cfg.ProxyURL)
 
 	var cronSvc *service.CronService
 	if db.IsEnabled() {

--- a/backend/cmd/api/main.go
+++ b/backend/cmd/api/main.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"log"
+	"time"
 
 	"github.com/gin-gonic/gin"
 	"github.com/joho/godotenv"
@@ -41,6 +42,14 @@ func main() {
 		cronSvc = service.NewCronService(db.DB, restClient, apnsClient)
 		cronSvc.Start()
 		defer cronSvc.Stop()
+
+		go func() {
+			time.Sleep(3 * time.Second)
+			log.Println("Startup: triggering initial crawl")
+			if err := cronSvc.RunCrawlNow(); err != nil {
+				log.Printf("Startup crawl error: %v", err)
+			}
+		}()
 	}
 
 	r := gin.Default()

--- a/backend/internal/config/config.go
+++ b/backend/internal/config/config.go
@@ -11,6 +11,7 @@ type Config struct {
 	APNSKeyPath  string
 	APNSKey      string
 	APNSEnv      string
+	ProxyURL     string
 }
 
 func Load() *Config {
@@ -31,5 +32,6 @@ func Load() *Config {
 		APNSKeyPath:  os.Getenv("APNS_KEY_PATH"),
 		APNSKey:      os.Getenv("APNS_KEY"),
 		APNSEnv:      apnsEnv,
+		ProxyURL:     os.Getenv("WEBSHARE_PROXY_URL"),
 	}
 }

--- a/backend/internal/db/db.go
+++ b/backend/internal/db/db.go
@@ -37,6 +37,7 @@ func Init(cfg *config.Config) error {
 
 	if err := DB.AutoMigrate(
 		&model.Campaign{},
+		&model.CampaignSnapshot{},
 		&model.Category{},
 		&model.Device{},
 		&model.Alert{},

--- a/backend/internal/handler/alerts.go
+++ b/backend/internal/handler/alerts.go
@@ -11,16 +11,31 @@ import (
 )
 
 type createAlertRequest struct {
-	DeviceID   string  `json:"device_id" binding:"required"`
-	Keyword    string  `json:"keyword" binding:"required"`
-	CategoryID string  `json:"category_id"`
-	MinPercent float64 `json:"min_percent"`
+	DeviceID       string  `json:"device_id" binding:"required"`
+	AlertType      string  `json:"alert_type"`
+	Keyword        string  `json:"keyword"`
+	CategoryID     string  `json:"category_id"`
+	MinPercent     float64 `json:"min_percent"`
+	VelocityThresh float64 `json:"velocity_thresh"`
 }
 
 func CreateAlert(c *gin.Context) {
 	var req createAlertRequest
 	if err := c.ShouldBindJSON(&req); err != nil {
 		c.JSON(http.StatusBadRequest, gin.H{"error": err.Error()})
+		return
+	}
+
+	alertType := req.AlertType
+	if alertType == "" {
+		alertType = "keyword"
+	}
+	if alertType == "keyword" && req.Keyword == "" {
+		c.JSON(http.StatusBadRequest, gin.H{"error": "keyword is required for keyword alerts"})
+		return
+	}
+	if alertType == "momentum" && req.VelocityThresh <= 0 {
+		c.JSON(http.StatusBadRequest, gin.H{"error": "velocity_thresh must be > 0 for momentum alerts"})
 		return
 	}
 
@@ -31,11 +46,13 @@ func CreateAlert(c *gin.Context) {
 	}
 
 	alert := model.Alert{
-		DeviceID:   deviceID,
-		Keyword:    req.Keyword,
-		CategoryID: req.CategoryID,
-		MinPercent: req.MinPercent,
-		IsEnabled:  true,
+		DeviceID:       deviceID,
+		AlertType:      alertType,
+		Keyword:        req.Keyword,
+		CategoryID:     req.CategoryID,
+		MinPercent:     req.MinPercent,
+		VelocityThresh: req.VelocityThresh,
+		IsEnabled:      true,
 	}
 	if err := db.DB.Create(&alert).Error; err != nil {
 		c.JSON(http.StatusInternalServerError, gin.H{"error": err.Error()})

--- a/backend/internal/handler/campaigns.go
+++ b/backend/internal/handler/campaigns.go
@@ -19,10 +19,6 @@ var sortMap = map[string]string{
 func ListCampaigns(graphClient *service.KickstarterGraphClient) gin.HandlerFunc {
 	return func(c *gin.Context) {
 		sort := c.DefaultQuery("sort", "trending")
-		gqlSort, ok := sortMap[sort]
-		if !ok {
-			gqlSort = "MAGIC"
-		}
 		categoryID := c.Query("category_id")
 		cursor := c.Query("cursor")
 		limit, _ := strconv.Atoi(c.DefaultQuery("limit", "20"))
@@ -30,8 +26,38 @@ func ListCampaigns(graphClient *service.KickstarterGraphClient) gin.HandlerFunc 
 			limit = 50
 		}
 
+		// "hot" sort: served from DB by velocity_24h
+		if sort == "hot" && db.IsEnabled() {
+			var campaigns []model.Campaign
+			q := db.DB.Where("state = 'live'").Order("velocity_24h DESC").Limit(limit)
+			if categoryID != "" {
+				q = q.Where("category_id = ?", categoryID)
+			}
+			if err := q.Find(&campaigns).Error; err == nil {
+				c.JSON(http.StatusOK, gin.H{"campaigns": campaigns, "next_cursor": nil, "total": len(campaigns)})
+				return
+			}
+		}
+
+		gqlSort, ok := sortMap[sort]
+		if !ok {
+			gqlSort = "MAGIC"
+		}
+
 		result, err := graphClient.Search("", categoryID, gqlSort, cursor, limit)
 		if err != nil {
+			// fallback to DB if GraphQL fails
+			if db.IsEnabled() {
+				var campaigns []model.Campaign
+				q := db.DB.Where("state = 'live'").Order("last_updated_at DESC").Limit(limit)
+				if categoryID != "" {
+					q = q.Where("category_id = ?", categoryID)
+				}
+				if dbErr := q.Find(&campaigns).Error; dbErr == nil && len(campaigns) > 0 {
+					c.JSON(http.StatusOK, gin.H{"campaigns": campaigns, "next_cursor": nil, "total": len(campaigns)})
+					return
+				}
+			}
 			c.JSON(http.StatusInternalServerError, gin.H{"error": err.Error()})
 			return
 		}

--- a/backend/internal/model/model.go
+++ b/backend/internal/model/model.go
@@ -23,8 +23,25 @@ type Campaign struct {
 	CreatorName   string    `json:"creator_name"`
 	PercentFunded float64   `json:"percent_funded"`
 	Slug          string    `json:"slug"`
+	Velocity24h   float64   `gorm:"default:0" json:"velocity_24h"`
+	PleDelta24h   float64   `gorm:"default:0" json:"pledge_delta_24h"`
 	FirstSeenAt   time.Time `gorm:"not null;default:now()" json:"first_seen_at"`
 	LastUpdatedAt time.Time `gorm:"not null;default:now()" json:"last_updated_at"`
+}
+
+type CampaignSnapshot struct {
+	ID            uuid.UUID `gorm:"type:uuid;primaryKey" json:"id"`
+	CampaignPID   string    `gorm:"index;not null" json:"campaign_pid"`
+	PledgedAmount float64   `json:"pledged_amount"`
+	PercentFunded float64   `json:"percent_funded"`
+	SnapshotAt    time.Time `gorm:"index;not null;default:now()" json:"snapshot_at"`
+}
+
+func (s *CampaignSnapshot) BeforeCreate(tx *gorm.DB) error {
+	if s.ID == uuid.Nil {
+		s.ID = uuid.New()
+	}
+	return nil
 }
 
 type Category struct {
@@ -47,19 +64,24 @@ func (d *Device) BeforeCreate(tx *gorm.DB) error {
 }
 
 type Alert struct {
-	ID            uuid.UUID  `gorm:"type:uuid;primaryKey" json:"id"`
-	DeviceID      uuid.UUID  `gorm:"type:uuid;index;not null" json:"device_id"`
-	Keyword       string     `gorm:"not null" json:"keyword"`
-	CategoryID    string     `json:"category_id,omitempty"`
-	MinPercent    float64    `gorm:"default:0" json:"min_percent"`
-	IsEnabled     bool       `gorm:"default:true" json:"is_enabled"`
-	CreatedAt     time.Time  `json:"created_at"`
-	LastMatchedAt *time.Time `json:"last_matched_at,omitempty"`
+	ID             uuid.UUID  `gorm:"type:uuid;primaryKey" json:"id"`
+	DeviceID       uuid.UUID  `gorm:"type:uuid;index;not null" json:"device_id"`
+	AlertType      string     `gorm:"not null;default:'keyword'" json:"alert_type"`
+	Keyword        string     `json:"keyword"`
+	CategoryID     string     `json:"category_id,omitempty"`
+	MinPercent     float64    `gorm:"default:0" json:"min_percent"`
+	VelocityThresh float64    `gorm:"default:0" json:"velocity_thresh"`
+	IsEnabled      bool       `gorm:"default:true" json:"is_enabled"`
+	CreatedAt      time.Time  `json:"created_at"`
+	LastMatchedAt  *time.Time `json:"last_matched_at,omitempty"`
 }
 
 func (a *Alert) BeforeCreate(tx *gorm.DB) error {
 	if a.ID == uuid.Nil {
 		a.ID = uuid.New()
+	}
+	if a.AlertType == "" {
+		a.AlertType = "keyword"
 	}
 	return nil
 }

--- a/backend/internal/service/cron.go
+++ b/backend/internal/service/cron.go
@@ -34,7 +34,7 @@ func NewCronService(db *gorm.DB, restClient *KickstarterRESTClient, apns *APNsCl
 func (s *CronService) Start() {
 	s.scheduler.AddFunc("0 2 * * *", func() {
 		log.Println("Cron: starting nightly crawl")
-		if err := s.runCrawl(); err != nil {
+		if err := s.RunCrawlNow(); err != nil {
 			log.Printf("Cron: crawl error: %v", err)
 		}
 	})
@@ -46,8 +46,10 @@ func (s *CronService) Stop() {
 	s.scheduler.Stop()
 }
 
-func (s *CronService) runCrawl() error {
+func (s *CronService) RunCrawlNow() error {
 	upserted := 0
+	var allCampaigns []model.Campaign
+
 	for _, catID := range rootCategories {
 		for page := 1; page <= 10; page++ {
 			campaigns, err := s.restClient.DiscoverCampaigns(catID, "newest", page)
@@ -74,13 +76,58 @@ func (s *CronService) runCrawl() error {
 				log.Printf("Cron: upsert error: %v", result.Error)
 			} else {
 				upserted += len(campaigns)
+				allCampaigns = append(allCampaigns, campaigns...)
 			}
 			time.Sleep(500 * time.Millisecond)
 		}
 	}
 	log.Printf("Cron: crawl done, upserted %d campaigns", upserted)
 
+	if len(allCampaigns) > 0 {
+		s.storeSnapshots(allCampaigns)
+		s.computeVelocity(allCampaigns)
+	}
+
 	return s.matchAlerts()
+}
+
+func (s *CronService) storeSnapshots(campaigns []model.Campaign) {
+	snapshots := make([]model.CampaignSnapshot, 0, len(campaigns))
+	now := time.Now()
+	for _, c := range campaigns {
+		snapshots = append(snapshots, model.CampaignSnapshot{
+			CampaignPID:   c.PID,
+			PledgedAmount: c.PledgedAmount,
+			PercentFunded: c.PercentFunded,
+			SnapshotAt:    now,
+		})
+	}
+	if err := s.db.Create(&snapshots).Error; err != nil {
+		log.Printf("Cron: snapshot insert error: %v", err)
+	}
+}
+
+func (s *CronService) computeVelocity(campaigns []model.Campaign) {
+	cutoff := time.Now().Add(-25 * time.Hour)
+
+	for _, c := range campaigns {
+		var prev model.CampaignSnapshot
+		err := s.db.Where("campaign_pid = ? AND snapshot_at < ?", c.PID, cutoff).
+			Order("snapshot_at DESC").First(&prev).Error
+		if err != nil {
+			continue
+		}
+		if prev.PledgedAmount <= 0 {
+			continue
+		}
+		delta := c.PledgedAmount - prev.PledgedAmount
+		velocityPct := (delta / prev.PledgedAmount) * 100
+
+		s.db.Model(&model.Campaign{}).Where("pid = ?", c.PID).Updates(map[string]interface{}{
+			"velocity_24h":  velocityPct,
+			"ple_delta_24h": delta,
+		})
+	}
 }
 
 func (s *CronService) matchAlerts() error {
@@ -93,17 +140,33 @@ func (s *CronService) matchAlerts() error {
 
 	for _, alert := range alerts {
 		var campaigns []model.Campaign
-		query := s.db.Where(
-			"first_seen_at > ? AND name ILIKE ? AND percent_funded >= ?",
-			cutoff, "%"+alert.Keyword+"%", alert.MinPercent,
-		)
-		if alert.CategoryID != "" {
-			query = query.Where("category_id = ?", alert.CategoryID)
+
+		switch alert.AlertType {
+		case "momentum":
+			if alert.VelocityThresh <= 0 {
+				continue
+			}
+			if err := s.db.Where(
+				"first_seen_at > ? AND velocity_24h >= ?",
+				cutoff, alert.VelocityThresh,
+			).Find(&campaigns).Error; err != nil {
+				log.Printf("Cron: momentum match error for alert %s: %v", alert.ID, err)
+				continue
+			}
+		default: // "keyword"
+			query := s.db.Where(
+				"first_seen_at > ? AND name ILIKE ? AND percent_funded >= ?",
+				cutoff, "%"+alert.Keyword+"%", alert.MinPercent,
+			)
+			if alert.CategoryID != "" {
+				query = query.Where("category_id = ?", alert.CategoryID)
+			}
+			if err := query.Find(&campaigns).Error; err != nil {
+				log.Printf("Cron: keyword match error for alert %s: %v", alert.ID, err)
+				continue
+			}
 		}
-		if err := query.Find(&campaigns).Error; err != nil {
-			log.Printf("Cron: match query error for alert %s: %v", alert.ID, err)
-			continue
-		}
+
 		if len(campaigns) == 0 {
 			continue
 		}
@@ -135,8 +198,16 @@ func (s *CronService) sendAlertPush(alert model.Alert, matchCount int) {
 		return
 	}
 
+	var title string
+	switch alert.AlertType {
+	case "momentum":
+		title = fmt.Sprintf("%d campaigns surged +%.0f%% today", matchCount, alert.VelocityThresh)
+	default:
+		title = fmt.Sprintf("%d new \"%s\" campaigns", matchCount, alert.Keyword)
+	}
+
 	payload := APNsPayload{}
-	payload.APS.Alert.Title = fmt.Sprintf("%d new \"%s\" campaigns", matchCount, alert.Keyword)
+	payload.APS.Alert.Title = title
 	payload.APS.Alert.Body = "Tap to see today's matches in KickWatch"
 	payload.APS.Badge = 1
 	payload.APS.Sound = "default"

--- a/backend/internal/service/kickstarter_graph.go
+++ b/backend/internal/service/kickstarter_graph.go
@@ -50,8 +50,16 @@ func (c *KickstarterGraphClient) ensureSession() error {
 	}
 
 	req, _ := http.NewRequest("GET", ksBaseURL, nil)
-	req.Header.Set("User-Agent", "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36")
-	req.Header.Set("Accept", "text/html")
+	req.Header.Set("User-Agent", "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/121.0.0.0 Safari/537.36")
+	req.Header.Set("Accept", "text/html,application/xhtml+xml,application/xml;q=0.9,image/avif,image/webp,*/*;q=0.8")
+	req.Header.Set("Accept-Language", "en-US,en;q=0.9")
+	req.Header.Set("Accept-Encoding", "gzip, deflate, br")
+	req.Header.Set("Connection", "keep-alive")
+	req.Header.Set("Upgrade-Insecure-Requests", "1")
+	req.Header.Set("Sec-Fetch-Dest", "document")
+	req.Header.Set("Sec-Fetch-Mode", "navigate")
+	req.Header.Set("Sec-Fetch-Site", "none")
+	req.Header.Set("Sec-Fetch-User", "?1")
 
 	resp, err := c.httpClient.Do(req)
 	if err != nil {

--- a/backend/internal/service/kickstarter_graph.go
+++ b/backend/internal/service/kickstarter_graph.go
@@ -7,6 +7,7 @@ import (
 	"io"
 	"log"
 	"net/http"
+	"net/url"
 	"regexp"
 	"strconv"
 	"sync"
@@ -35,9 +36,25 @@ type KickstarterGraphClient struct {
 	httpClient *http.Client
 }
 
-func NewKickstarterGraphClient() *KickstarterGraphClient {
+func NewKickstarterGraphClient(proxyURL string) *KickstarterGraphClient {
+	transport := &http.Transport{
+		DisableCompression: false,
+		ForceAttemptHTTP2:  false, // must be false when using HTTP proxy
+	}
+	if proxyURL != "" {
+		parsed, err := url.Parse(proxyURL)
+		if err == nil {
+			transport.Proxy = http.ProxyURL(parsed)
+			log.Printf("KickstarterGraphClient: using proxy %s://%s", parsed.Scheme, parsed.Host)
+		} else {
+			log.Printf("KickstarterGraphClient: invalid proxy URL, ignoring: %v", err)
+		}
+	}
 	return &KickstarterGraphClient{
-		httpClient: &http.Client{Timeout: 30 * time.Second},
+		httpClient: &http.Client{
+			Timeout:   30 * time.Second,
+			Transport: transport,
+		},
 	}
 }
 
@@ -53,7 +70,6 @@ func (c *KickstarterGraphClient) ensureSession() error {
 	req.Header.Set("User-Agent", "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/121.0.0.0 Safari/537.36")
 	req.Header.Set("Accept", "text/html,application/xhtml+xml,application/xml;q=0.9,image/avif,image/webp,*/*;q=0.8")
 	req.Header.Set("Accept-Language", "en-US,en;q=0.9")
-	req.Header.Set("Accept-Encoding", "gzip, deflate, br")
 	req.Header.Set("Connection", "keep-alive")
 	req.Header.Set("Upgrade-Insecure-Requests", "1")
 	req.Header.Set("Sec-Fetch-Dest", "document")

--- a/backend/internal/service/kickstarter_rest.go
+++ b/backend/internal/service/kickstarter_rest.go
@@ -3,6 +3,7 @@ package service
 import (
 	"encoding/json"
 	"fmt"
+	"log"
 	"net/http"
 	"net/url"
 	"strconv"
@@ -50,9 +51,22 @@ type KickstarterRESTClient struct {
 	httpClient *http.Client
 }
 
-func NewKickstarterRESTClient() *KickstarterRESTClient {
+func NewKickstarterRESTClient(proxyURL string) *KickstarterRESTClient {
+	transport := &http.Transport{}
+	if proxyURL != "" {
+		parsed, err := url.Parse(proxyURL)
+		if err == nil {
+			transport.Proxy = http.ProxyURL(parsed)
+			log.Printf("KickstarterRESTClient: using proxy %s://%s", parsed.Scheme, parsed.Host)
+		} else {
+			log.Printf("KickstarterRESTClient: invalid proxy URL, ignoring: %v", err)
+		}
+	}
 	return &KickstarterRESTClient{
-		httpClient: &http.Client{Timeout: 30 * time.Second},
+		httpClient: &http.Client{
+			Timeout:   30 * time.Second,
+			Transport: transport,
+		},
 	}
 }
 

--- a/ios/KickWatch/Sources/Services/APIClient.swift
+++ b/ios/KickWatch/Sources/Services/APIClient.swift
@@ -16,6 +16,9 @@ struct CampaignDTO: Codable {
     let creator_name: String?
     let percent_funded: Double?
     let slug: String?
+    let velocity_24h: Double?
+    let pledge_delta_24h: Double?
+    let first_seen_at: String?
 }
 
 struct CategoryDTO: Codable {
@@ -45,17 +48,21 @@ struct RegisterDeviceResponse: Codable {
 
 struct CreateAlertRequest: Codable {
     let device_id: String
-    let keyword: String
+    let alert_type: String?
+    let keyword: String?
     let category_id: String?
     let min_percent: Double?
+    let velocity_thresh: Double?
 }
 
 struct AlertDTO: Codable {
     let id: String
     let device_id: String
+    let alert_type: String?
     let keyword: String
     let category_id: String?
     let min_percent: Double
+    let velocity_thresh: Double?
     let is_enabled: Bool
     let created_at: String
     let last_matched_at: String?

--- a/ios/KickWatch/Sources/ViewModels/AlertsViewModel.swift
+++ b/ios/KickWatch/Sources/ViewModels/AlertsViewModel.swift
@@ -17,12 +17,14 @@ final class AlertsViewModel {
         isLoading = false
     }
 
-    func createAlert(deviceID: String, keyword: String, categoryID: String?, minPercent: Double) async {
+    func createAlert(deviceID: String, alertType: String = "keyword", keyword: String = "", categoryID: String? = nil, minPercent: Double = 0, velocityThresh: Double = 0) async {
         let req = CreateAlertRequest(
             device_id: deviceID,
-            keyword: keyword,
+            alert_type: alertType,
+            keyword: keyword.isEmpty ? nil : keyword,
             category_id: categoryID,
-            min_percent: minPercent > 0 ? minPercent : nil
+            min_percent: minPercent > 0 ? minPercent : nil,
+            velocity_thresh: velocityThresh > 0 ? velocityThresh : nil
         )
         do {
             let alert = try await APIClient.shared.createAlert(req)

--- a/ios/KickWatch/Sources/Views/AlertsView.swift
+++ b/ios/KickWatch/Sources/Views/AlertsView.swift
@@ -64,12 +64,17 @@ struct AlertRowView: View {
     var body: some View {
         HStack {
             VStack(alignment: .leading, spacing: 4) {
-                Text("\"\(alert.keyword)\"").font(.subheadline).fontWeight(.semibold)
-                Group {
-                    if let cat = alert.category_id { Text("Category: \(cat)") }
-                    if alert.min_percent > 0 { Text("Min \(Int(alert.min_percent))% funded") }
+                if alert.alert_type == "momentum" {
+                    Text("🔥 Momentum Alert").font(.subheadline).fontWeight(.semibold)
+                    Text("+\(Int(alert.velocity_thresh ?? 0))% in 24h").font(.caption).foregroundStyle(.secondary)
+                } else {
+                    Text("\"\(alert.keyword)\"").font(.subheadline).fontWeight(.semibold)
+                    Group {
+                        if let cat = alert.category_id { Text("Category: \(cat)") }
+                        if alert.min_percent > 0 { Text("Min \(Int(alert.min_percent))% funded") }
+                    }
+                    .font(.caption).foregroundStyle(.secondary)
                 }
-                .font(.caption).foregroundStyle(.secondary)
             }
             Spacer()
             Toggle("", isOn: Binding(
@@ -84,21 +89,44 @@ struct AlertRowView: View {
 
 struct NewAlertSheet: View {
     let vm: AlertsViewModel
+    @State private var alertType = "keyword"
     @State private var keyword = ""
     @State private var minPercent = 0.0
+    @State private var velocityThresh = 50.0
     @Environment(\.dismiss) private var dismiss
+
+    private var isValid: Bool {
+        guard let deviceID = NotificationService.shared.deviceID, !deviceID.isEmpty else { return false }
+        return alertType == "momentum" ? true : !keyword.isEmpty
+    }
 
     var body: some View {
         NavigationStack {
             Form {
-                Section("Keyword") {
-                    TextField("e.g. mechanical keyboard", text: $keyword)
-                }
-                Section("Min % Funded") {
-                    Slider(value: $minPercent, in: 0...100, step: 10) {
-                        Text("\(Int(minPercent))%")
+                Section("Alert Type") {
+                    Picker("Type", selection: $alertType) {
+                        Text("Keyword").tag("keyword")
+                        Text("🔥 Momentum").tag("momentum")
                     }
-                    Text("\(Int(minPercent))% minimum").foregroundStyle(.secondary)
+                    .pickerStyle(.segmented)
+                }
+
+                if alertType == "keyword" {
+                    Section("Keyword") {
+                        TextField("e.g. mechanical keyboard", text: $keyword)
+                    }
+                    Section("Min % Funded") {
+                        Slider(value: $minPercent, in: 0...100, step: 10)
+                        Text("\(Int(minPercent))% minimum").foregroundStyle(.secondary)
+                    }
+                } else {
+                    Section {
+                        Slider(value: $velocityThresh, in: 25...500, step: 25)
+                        Text("Alert when a campaign grows +\(Int(velocityThresh))% in 24h")
+                            .foregroundStyle(.secondary)
+                    } header: {
+                        Text("Growth Threshold")
+                    }
                 }
             }
             .navigationTitle("New Alert")
@@ -107,13 +135,20 @@ struct NewAlertSheet: View {
                 ToolbarItem(placement: .cancellationAction) { Button("Cancel") { dismiss() } }
                 ToolbarItem(placement: .confirmationAction) {
                     Button("Save") {
-                        guard !keyword.isEmpty, let deviceID = NotificationService.shared.deviceID else { return }
+                        guard let deviceID = NotificationService.shared.deviceID else { return }
                         Task {
-                            await vm.createAlert(deviceID: deviceID, keyword: keyword, categoryID: nil, minPercent: minPercent)
+                            await vm.createAlert(
+                                deviceID: deviceID,
+                                alertType: alertType,
+                                keyword: keyword,
+                                categoryID: nil,
+                                minPercent: minPercent,
+                                velocityThresh: alertType == "momentum" ? velocityThresh : 0
+                            )
                             dismiss()
                         }
                     }
-                    .disabled(keyword.isEmpty)
+                    .disabled(!isValid)
                 }
             }
         }

--- a/ios/KickWatch/Sources/Views/CampaignRowView.swift
+++ b/ios/KickWatch/Sources/Views/CampaignRowView.swift
@@ -44,8 +44,32 @@ struct CampaignRowView: View {
                     Text("\(days)d left")
                         .font(.caption2).foregroundStyle(.secondary)
                 }
+                momentumBadge
             }
         }
+    }
+
+    @ViewBuilder
+    private var momentumBadge: some View {
+        if let v = campaign.velocity_24h, v > 0 {
+            let (icon, color): (String, Color) = v >= 200 ? ("🔥", .red) : ("⚡", .orange)
+            Text("\(icon) +\(Int(v))%")
+                .font(.caption2).fontWeight(.semibold)
+                .foregroundStyle(color)
+        } else if isNew {
+            Text("New")
+                .font(.caption2).fontWeight(.semibold)
+                .padding(.horizontal, 5).padding(.vertical, 2)
+                .background(Color.blue.opacity(0.15))
+                .foregroundStyle(.blue)
+                .clipShape(Capsule())
+        }
+    }
+
+    private var isNew: Bool {
+        guard let s = campaign.first_seen_at,
+              let date = ISO8601DateFormatter().date(from: s) else { return false }
+        return Date().timeIntervalSince(date) < 48 * 3600
     }
 
     private var fundingBar: some View {

--- a/ios/KickWatch/Sources/Views/DiscoverView.swift
+++ b/ios/KickWatch/Sources/Views/DiscoverView.swift
@@ -6,7 +6,7 @@ struct DiscoverView: View {
     @State private var searchText = ""
     @State private var showSearch = false
 
-    private let sortOptions = [("trending", "Trending"), ("newest", "New"), ("ending", "Ending Soon")]
+    private let sortOptions = [("hot", "🔥 Hot"), ("trending", "Trending"), ("newest", "New"), ("ending", "Ending")]
 
     var body: some View {
         NavigationStack {

--- a/ios/KickWatch/Sources/Views/WatchlistView.swift
+++ b/ios/KickWatch/Sources/Views/WatchlistView.swift
@@ -53,7 +53,8 @@ struct WatchlistView: View {
             deadline: ISO8601DateFormatter().string(from: c.deadline),
             state: c.state, category_name: c.categoryName, category_id: c.categoryID,
             project_url: c.projectURL, creator_name: c.creatorName,
-            percent_funded: c.percentFunded, slug: nil
+            percent_funded: c.percentFunded, slug: nil,
+            velocity_24h: nil, pledge_delta_24h: nil, first_seen_at: nil
         )
     }
 }


### PR DESCRIPTION
## Investor-Facing Metrics

### Backend
- **`CampaignSnapshot`** table — stores pledged/percent snapshots on every crawl
- **`Campaign.velocity_24h`** — % change in pledged amount vs 24h-ago snapshot
- **`Campaign.pledge_delta_24h`** — absolute $ change in 24h
- **`Alert.alert_type`** (`keyword` | `momentum`) + **`velocity_thresh`** — momentum alerts fire when a campaign grows above the threshold in 24h
- **`RunCrawlNow()`** (exported) — server triggers an initial crawl 3s after startup so data is available immediately after deploy
- **`sort=hot`** — served from DB by `velocity_24h DESC`; also serves as DB fallback when Kickstarter GraphQL is unreachable
- Stronger Cloudflare bypass headers on session bootstrap

### iOS
- `CampaignDTO`: `velocity_24h`, `pledge_delta_24h`, `first_seen_at`
- **Momentum badge** on campaign rows: `⚡ +N%` (orange ≥50%) / `🔥 +N%` (red ≥200%) / `New` (blue, <48h)
- **🔥 Hot** sort option in Discover
- **Momentum alert** type in New Alert sheet — slider sets growth threshold (25%–500%)