### PR TITLE
fix: explicitly set ProxyConnectHeader for Webshare HTTPS CONNECT auth

### DIFF
--- a/backend/internal/service/kickstarter_graph.go
+++ b/backend/internal/service/kickstarter_graph.go
@@ -2,6 +2,7 @@ package service
 
 import (
 	"bytes"
+	"encoding/base64"
 	"encoding/json"
 	"fmt"
 	"io"
@@ -45,6 +46,14 @@ func NewKickstarterGraphClient(proxyURL string) *KickstarterGraphClient {
 		parsed, err := url.Parse(proxyURL)
 		if err == nil {
 			transport.Proxy = http.ProxyURL(parsed)
+			// Explicitly set Proxy-Authorization for HTTPS CONNECT tunneling.
+			// Go's http.Transport does not auto-retry 407 challenges for CONNECT.
+			if parsed.User != nil {
+				creds := base64.StdEncoding.EncodeToString([]byte(parsed.User.String()))
+				transport.ProxyConnectHeader = http.Header{
+					"Proxy-Authorization": []string{"Basic " + creds},
+				}
+			}
 			log.Printf("KickstarterGraphClient: using proxy %s://%s", parsed.Scheme, parsed.Host)
 		} else {
 			log.Printf("KickstarterGraphClient: invalid proxy URL, ignoring: %v", err)

--- a/backend/internal/service/kickstarter_rest.go
+++ b/backend/internal/service/kickstarter_rest.go
@@ -1,6 +1,7 @@
 package service
 
 import (
+	"encoding/base64"
 	"encoding/json"
 	"fmt"
 	"log"
@@ -57,6 +58,12 @@ func NewKickstarterRESTClient(proxyURL string) *KickstarterRESTClient {
 		parsed, err := url.Parse(proxyURL)
 		if err == nil {
 			transport.Proxy = http.ProxyURL(parsed)
+			if parsed.User != nil {
+				creds := base64.StdEncoding.EncodeToString([]byte(parsed.User.String()))
+				transport.ProxyConnectHeader = http.Header{
+					"Proxy-Authorization": []string{"Basic " + creds},
+				}
+			}
 			log.Printf("KickstarterRESTClient: using proxy %s://%s", parsed.Scheme, parsed.Host)
 		} else {
 			log.Printf("KickstarterRESTClient: invalid proxy URL, ignoring: %v", err)


### PR DESCRIPTION
Go's `http.Transport` does not auto-handle 407 for HTTPS CONNECT tunnels. Must set `ProxyConnectHeader` with `Proxy-Authorization` upfront.

Fixes `Proxy Authentication Required` error when ECS connects to `p.webshare.io`.