### PR TITLE
feat(#12): crawl subcategories in nightly cron

### DIFF
--- a/backend/internal/service/categories.go
+++ b/backend/internal/service/categories.go
@@ -2,22 +2,75 @@ package service
 
 import "github.com/kickwatch/backend/internal/model"
 
-// kickstarterCategories is a hardcoded list of Kickstarter root categories
-// These rarely change, so we avoid API calls by maintaining this static list
+// kickstarterCategories lists root and high-value subcategories.
+// Root IDs and subcategory IDs confirmed from Kickstarter REST API public datasets.
 var kickstarterCategories = []model.Category{
+	// Root categories
 	{ID: "1", Name: "Art"},
 	{ID: "3", Name: "Comics"},
 	{ID: "4", Name: "Crafts"},
 	{ID: "5", Name: "Dance"},
-	{ID: "6", Name: "Design"},
-	{ID: "7", Name: "Fashion"},
-	{ID: "9", Name: "Film & Video"},
+	{ID: "7", Name: "Design"},
+	{ID: "9", Name: "Fashion"},
 	{ID: "10", Name: "Food"},
-	{ID: "11", Name: "Games"},
-	{ID: "12", Name: "Journalism"},
+	{ID: "11", Name: "Film & Video"},
+	{ID: "12", Name: "Games"},
 	{ID: "13", Name: "Music"},
 	{ID: "14", Name: "Photography"},
-	{ID: "15", Name: "Publishing"},
 	{ID: "16", Name: "Technology"},
 	{ID: "17", Name: "Theater"},
+	{ID: "18", Name: "Publishing"},
+
+	// Design subcategories
+	{ID: "28", Name: "Product Design", ParentID: "7"},
+
+	// Fashion subcategories
+	{ID: "263", Name: "Apparel", ParentID: "9"},
+
+	// Film & Video subcategories
+	{ID: "29", Name: "Animation", ParentID: "11"},
+	{ID: "303", Name: "Television", ParentID: "11"},
+
+	// Games subcategories
+	{ID: "34", Name: "Tabletop Games", ParentID: "12"},
+	{ID: "35", Name: "Video Games", ParentID: "12"},
+	{ID: "270", Name: "Gaming Hardware", ParentID: "12"},
+
+	// Technology subcategories
+	{ID: "52", Name: "Hardware", ParentID: "16"},
+	{ID: "331", Name: "3D Printing", ParentID: "16"},
+	{ID: "337", Name: "Gadgets", ParentID: "16"},
+	{ID: "339", Name: "Sound", ParentID: "16"},
+
+	// Publishing subcategories
+	{ID: "47", Name: "Fiction", ParentID: "18"},
+}
+
+// crawlCategories defines all category IDs to crawl and their page depth.
+// Root categories get deeper crawls; subcategories are more focused.
+var crawlCategories = []crawlCategory{
+	// Root categories — 10 pages each (~200 items)
+	{"1", 10}, {"3", 10}, {"4", 10}, {"5", 10},
+	{"7", 10}, {"9", 10}, {"10", 10}, {"11", 10},
+	{"12", 10}, {"13", 10}, {"14", 10}, {"16", 10},
+	{"17", 10}, {"18", 10},
+
+	// High-value subcategories — 5 pages each (~100 items)
+	{"28", 5},  // Product Design
+	{"34", 5},  // Tabletop Games
+	{"35", 5},  // Video Games
+	{"270", 5}, // Gaming Hardware
+	{"52", 5},  // Hardware
+	{"331", 5}, // 3D Printing
+	{"337", 5}, // Gadgets
+	{"339", 5}, // Sound
+	{"47", 5},  // Fiction
+	{"29", 5},  // Animation
+	{"303", 5}, // Television
+	{"263", 5}, // Apparel
+}
+
+type crawlCategory struct {
+	ID        string
+	PageDepth int
 }

--- a/backend/internal/service/cron.go
+++ b/backend/internal/service/cron.go
@@ -42,7 +42,23 @@ func (s *CronService) Stop() {
 	s.scheduler.Stop()
 }
 
+// syncCategories upserts the canonical category list into the DB so that
+// clients and alert filters always see the current IDs and subcategories.
+func (s *CronService) syncCategories() {
+	result := s.db.Clauses(clause.OnConflict{
+		Columns:   []clause.Column{{Name: "id"}},
+		DoUpdates: clause.AssignmentColumns([]string{"name", "parent_id"}),
+	}).Create(&kickstarterCategories)
+	if result.Error != nil {
+		log.Printf("Cron: category sync error: %v", result.Error)
+	} else {
+		log.Printf("Cron: synced %d categories", len(kickstarterCategories))
+	}
+}
+
 func (s *CronService) RunCrawlNow() error {
+	s.syncCategories()
+
 	upserted := 0
 	var allCampaigns []model.Campaign
 

--- a/backend/internal/service/cron.go
+++ b/backend/internal/service/cron.go
@@ -11,10 +11,6 @@ import (
 	"gorm.io/gorm/clause"
 )
 
-var rootCategories = []string{
-	"1", "3", "4", "5", "6", "7", "9", "10", "11", "12", "13", "14", "15", "16", "17",
-}
-
 type CronService struct {
 	db              *gorm.DB
 	scrapingService *KickstarterScrapingService
@@ -50,11 +46,11 @@ func (s *CronService) RunCrawlNow() error {
 	upserted := 0
 	var allCampaigns []model.Campaign
 
-	for _, catID := range rootCategories {
-		for page := 1; page <= 10; page++ {
-			campaigns, err := s.scrapingService.DiscoverCampaigns(catID, "newest", page)
+	for _, cat := range crawlCategories {
+		for page := 1; page <= cat.PageDepth; page++ {
+			campaigns, err := s.scrapingService.DiscoverCampaigns(cat.ID, "newest", page)
 			if err != nil {
-				log.Printf("Cron: ScrapingBee error cat=%s page=%d: %v", catID, page, err)
+				log.Printf("Cron: ScrapingBee error cat=%s page=%d: %v", cat.ID, page, err)
 				break
 			}
 			if len(campaigns) == 0 {


### PR DESCRIPTION
Closes #12

## Changes
- Fix root category IDs (Design=7, Fashion=9, Film&Video=11, Games=12, Publishing=18) based on confirmed Kickstarter REST API data
- Add 12 high-value subcategories: Tabletop Games, Video Games, Gaming Hardware, Hardware, 3D Printing, Gadgets, Sound, Fiction, Animation, Television, Product Design, Apparel
- Replace flat `rootCategories []string` with `crawlCategory` structs carrying per-category page depth
- Root categories: 10 pages; subcategories: 5 pages

## Stack
This is PR 1/6 in a stack. Next: #13 (sort strategies)