### PR TITLE
fix(#15): ERROR log when crawl upserts fewer than 50 campaigns

### DIFF
--- a/backend/internal/service/cron.go
+++ b/backend/internal/service/cron.go
@@ -71,6 +71,7 @@ func (s *CronService) RunCrawlNow() error {
 	s.syncCategories()
 
 	upserted := 0
+	seenPIDs := make(map[string]struct{})
 	var allCampaigns []model.Campaign
 
 	for _, sortCfg := range crawlSorts {
@@ -104,6 +105,9 @@ func (s *CronService) RunCrawlNow() error {
 					log.Printf("Cron: upsert error: %v", result.Error)
 				} else {
 					upserted += len(campaigns)
+					for _, c := range campaigns {
+						seenPIDs[c.PID] = struct{}{}
+					}
 					allCampaigns = append(allCampaigns, campaigns...)
 				}
 				time.Sleep(500 * time.Millisecond)
@@ -116,10 +120,10 @@ func (s *CronService) RunCrawlNow() error {
 	// at least some campaigns. Zero almost certainly means a parse failure
 	// (e.g. Kickstarter changed their HTML structure), not a genuinely empty site.
 	const minExpectedCampaigns = 50
-	if upserted < minExpectedCampaigns {
-		log.Printf("ERROR: crawl sanity check FAILED — only %d campaigns upserted (expected >=%d). "+
+	if len(seenPIDs) < minExpectedCampaigns {
+		log.Printf("ERROR: crawl sanity check FAILED — only %d distinct campaigns seen (expected >=%d). "+
 			"Possible HTML structure change or ScrapingBee degradation. "+
-			"Check kickstarter_parser.go [data-project] selector.", upserted, minExpectedCampaigns)
+			"Check kickstarter_parser.go [data-project] selector.", len(seenPIDs), minExpectedCampaigns)
 	}
 
 	if len(allCampaigns) > 0 {

--- a/backend/internal/service/cron.go
+++ b/backend/internal/service/cron.go
@@ -112,6 +112,16 @@ func (s *CronService) RunCrawlNow() error {
 	}
 	log.Printf("Cron: crawl done, upserted %d campaigns", upserted)
 
+	// Sanity check: a full crawl across all categories should always yield
+	// at least some campaigns. Zero almost certainly means a parse failure
+	// (e.g. Kickstarter changed their HTML structure), not a genuinely empty site.
+	const minExpectedCampaigns = 50
+	if upserted < minExpectedCampaigns {
+		log.Printf("ERROR: crawl sanity check FAILED — only %d campaigns upserted (expected >=%d). "+
+			"Possible HTML structure change or ScrapingBee degradation. "+
+			"Check kickstarter_parser.go [data-project] selector.", upserted, minExpectedCampaigns)
+	}
+
 	if len(allCampaigns) > 0 {
 		s.storeSnapshots(allCampaigns)
 		s.computeVelocity(allCampaigns)


### PR DESCRIPTION
Closes #15

## Changes
- Post-crawl sanity check: if `upserted < 50`, emit `ERROR`-level log naming the likely cause (HTML selector change or ScrapingBee degradation)

## Stack
PR 4/6. Base: #21 (page depth). Next: #16 (backers_count)