### PR TITLE
feat(#16): add backers_count field to Campaign model

### DIFF
--- a/backend/internal/model/model.go
+++ b/backend/internal/model/model.go
@@ -22,6 +22,7 @@ type Campaign struct {
 	ProjectURL    string    `json:"project_url"`
 	CreatorName   string    `json:"creator_name"`
 	PercentFunded float64   `json:"percent_funded"`
+	BackersCount  int       `gorm:"default:0" json:"backers_count"`
 	Slug          string    `json:"slug"`
 	Velocity24h   float64   `gorm:"default:0" json:"velocity_24h"`
 	PleDelta24h   float64   `gorm:"default:0" json:"pledge_delta_24h"`

--- a/backend/internal/service/cron.go
+++ b/backend/internal/service/cron.go
@@ -97,7 +97,8 @@ func (s *CronService) RunCrawlNow() error {
 					DoUpdates: clause.AssignmentColumns([]string{
 						"name", "blurb", "photo_url", "goal_amount", "goal_currency",
 						"pledged_amount", "deadline", "state", "category_id", "category_name",
-						"project_url", "creator_name", "percent_funded", "slug", "last_updated_at",
+						"project_url", "creator_name", "percent_funded", "backers_count",
+						"slug", "last_updated_at",
 					}),
 				}).Create(&campaigns)
 				if result.Error != nil {

--- a/backend/internal/service/kickstarter_parser.go
+++ b/backend/internal/service/kickstarter_parser.go
@@ -105,6 +105,11 @@ func extractCampaignFromData(data map[string]interface{}) model.Campaign {
 		campaign.PercentFunded = percentFunded
 	}
 
+	// Extract backers count
+	if backers, ok := data["backers_count"].(float64); ok {
+		campaign.BackersCount = int(backers)
+	}
+
 	// Extract creator (name + slug for URL construction)
 	var creatorSlug string
 	if creator, ok := data["creator"].(map[string]interface{}); ok {

--- a/backend/internal/service/kickstarter_scraping.go
+++ b/backend/internal/service/kickstarter_scraping.go
@@ -197,6 +197,7 @@ func (s *KickstarterScrapingService) parseAIResponse(jsonData string) ([]model.C
 			CategoryName:  p.Category,
 			PhotoURL:      p.PhotoURL,
 			Blurb:         p.Blurb,
+			BackersCount:  p.BackersCount,
 		}
 
 		// Parse deadline


### PR DESCRIPTION
Closes #16

## Changes
- Add `BackersCount int` to `model.go`
- Populate from `data-project` JSON attribute in `kickstarter_parser.go`
- Include in nightly cron upsert column list

## Stack
PR 5/6. Base: #22 (parse alerting). Next: #18 (backfill)