### PR TITLE
fix: GORM column name mismatch — Campaign.PID saves as p_id instead of pid

### DIFF
--- a/backend/internal/model/model.go
+++ b/backend/internal/model/model.go
@@ -8,7 +8,7 @@ import (
 )
 
 type Campaign struct {
-	PID           string    `gorm:"primaryKey" json:"pid"`
+	PID           string    `gorm:"column:pid;primaryKey" json:"pid"`
 	Name          string    `gorm:"not null" json:"name"`
 	Blurb         string    `json:"blurb"`
 	PhotoURL      string    `json:"photo_url"`


### PR DESCRIPTION
## Problem
All nightly crawl upserts fail with:
```
ERROR: column "pid" does not exist (SQLSTATE 42703)
```
GORM v2 converts the field name `PID` → `p_id` (snake_case), but the DB column is `pid` and all `OnConflict` clauses reference `"pid"`.

## Fix
Add `gorm:"column:pid"` explicit tag to `Campaign.PID` so GORM uses the correct column name.

## Impact
ScrapingBee is successfully fetching data (confirmed in logs) — campaigns are just not being written to the DB. This fix unblocks all inserts.