### PR TITLE
fix: add missing velocity_24h and ple_delta_24h columns to campaigns table

### DIFF
--- a/backend/internal/db/db.go
+++ b/backend/internal/db/db.go
@@ -94,6 +94,31 @@ func Init(cfg *config.Config) error {
 		return fmt.Errorf("migrate campaigns pk: %w", err)
 	}
 
+	// Ensure velocity_24h and pledge_delta_24h columns exist (added in develop branch)
+	if err := DB.Exec(`
+		DO $$
+		BEGIN
+			-- Add velocity_24h column if it doesn't exist
+			IF NOT EXISTS (
+				SELECT 1 FROM information_schema.columns
+				WHERE table_name = 'campaigns' AND column_name = 'velocity_24h'
+			) THEN
+				ALTER TABLE campaigns ADD COLUMN velocity_24h DOUBLE PRECISION DEFAULT 0;
+			END IF;
+
+			-- Add pledge_delta_24h column if it doesn't exist (named ple_delta_24h in DB due to GORM naming)
+			IF NOT EXISTS (
+				SELECT 1 FROM information_schema.columns
+				WHERE table_name = 'campaigns' AND column_name = 'ple_delta_24h'
+			) THEN
+				ALTER TABLE campaigns ADD COLUMN ple_delta_24h DOUBLE PRECISION DEFAULT 0;
+			END IF;
+		END
+		$$;
+	`).Error; err != nil {
+		return fmt.Errorf("migrate velocity columns: %w", err)
+	}
+
 	log.Println("Database connected and migrated")
 	return nil
 }


### PR DESCRIPTION
## Problem

After deploying the Cloudflare challenge fix (aa9ad5e), the backend is failing with:
```
ERROR: column "velocity_24h" does not exist (SQLSTATE 42703)
```

The model has `Velocity24h` and `PleDelta24h` fields, but these columns don't exist in the dev database.

## Solution

Added idempotent migration in `db.go` to ensure both columns exist:
- `velocity_24h` - DOUBLE PRECISION DEFAULT 0
- `ple_delta_24h` - DOUBLE PRECISION DEFAULT 0

The migration runs on startup and is idempotent (safe to run multiple times).

## Testing

- ✅ Go build succeeds
- ✅ Tests pass
- Migration will run automatically on next deployment

## Related

- Follows up on #31 (CF challenge fix)
- Fixes SQLSTATE 42703 errors blocking API requests

🤖 Generated with [Claude Code](https://claude.com/claude-code)