### PR TITLE
fix(#34): rename campaign_snapshots.campaign_p_id to campaign_pid

### DIFF
--- a/backend/internal/db/db.go
+++ b/backend/internal/db/db.go
@@ -119,6 +119,23 @@ func Init(cfg *config.Config) error {
 		return fmt.Errorf("migrate velocity columns: %w", err)
 	}
 
+	// Fix campaign_snapshots FK: rename campaign_p_id -> campaign_pid (same issue as campaigns.pid)
+	if err := DB.Exec(`
+		DO $$
+		BEGIN
+			-- Rename column if it exists with old snake_case name
+			IF EXISTS (
+				SELECT 1 FROM information_schema.columns
+				WHERE table_name = 'campaign_snapshots' AND column_name = 'campaign_p_id'
+			) THEN
+				ALTER TABLE campaign_snapshots RENAME COLUMN campaign_p_id TO campaign_pid;
+			END IF;
+		END
+		$$;
+	`).Error; err != nil {
+		return fmt.Errorf("migrate campaign_snapshots fk: %w", err)
+	}
+
 	log.Println("Database connected and migrated")
 	return nil
 }

--- a/backend/internal/model/model.go
+++ b/backend/internal/model/model.go
@@ -32,7 +32,7 @@ type Campaign struct {
 
 type CampaignSnapshot struct {
 	ID            uuid.UUID `gorm:"type:uuid;primaryKey" json:"id"`
-	CampaignPID   string    `gorm:"index;not null" json:"campaign_pid"`
+	CampaignPID   string    `gorm:"column:campaign_pid;index;not null" json:"campaign_pid"`
 	PledgedAmount float64   `json:"pledged_amount"`
 	PercentFunded float64   `json:"percent_funded"`
 	SnapshotAt    time.Time `gorm:"index;not null;default:now()" json:"snapshot_at"`


### PR DESCRIPTION
## Problem

The `campaign_snapshots` table had a column name mismatch causing **5,614 snapshot insert failures** on each crawl:

```
ERROR: column "campaign_pid" does not exist (SQLSTATE 42703)
```

**Root cause**: `CampaignSnapshot.CampaignPID` field was missing `gorm:"column:campaign_pid"` tag, causing GORM to snake_case it as `campaign_p_id` (same issue as #24 for campaigns table).

## Solution

1. ✅ Added `column:campaign_pid` to GORM tag in model
2. ✅ Added idempotent migration to rename existing column

## Impact

Before:
- ❌ 5,614 snapshot inserts fail every crawl
- ❌ No historical data for sparkline charts
- ❌ Velocity calculations broken

After:
- ✅ Snapshots will be stored correctly
- ✅ Sparkline charts will have data
- ✅ Velocity tracking will work

## Testing

- ✅ Go build succeeds
- ✅ Tests pass
- Migration will run automatically on next deployment

## Related

- Fixes #34
- Related to #24 (original campaigns.pid column fix)

🤖 Generated with [Claude Code](https://claude.com/claude-code)