### PR TITLE
fix(#43,#44,#45,#46): state filter, cron status, category dedup & translation

### DIFF
--- a/backend/cmd/api/main.go
+++ b/backend/cmd/api/main.go
@@ -104,6 +104,7 @@ func main() {
 
 		if cronSvc != nil {
 			api.POST("/admin/backfill", handler.TriggerBackfill(cronSvc))
+			api.GET("/admin/cron-status", handler.CronStatus(cronSvc))
 		}
 	}
 

--- a/backend/internal/db/db.go
+++ b/backend/internal/db/db.go
@@ -200,6 +200,41 @@ func Init(cfg *config.Config) error {
 	}
 	log.Printf("DB init: deduplicated %d snapshot rows", dedup.RowsAffected)
 
+	// Fix duplicate categories: the Vertex AI translation created new category rows
+	// instead of updating existing ones. Merge name_zh from duplicates into originals
+	// and delete the duplicates. Duplicates are identified by having the same name
+	// but different IDs (originals use Kickstarter IDs like "1", "3", etc.).
+	if err := DB.Exec(`
+		DO $$
+		BEGIN
+			IF EXISTS (SELECT 1 FROM information_schema.tables WHERE table_name = 'categories') THEN
+				-- Update originals with name_zh from duplicates (match by name, prefer non-empty name_zh)
+				UPDATE categories orig
+				SET name_zh = dup.name_zh
+				FROM categories dup
+				WHERE orig.name = dup.name
+					AND orig.id <> dup.id
+					AND (orig.name_zh IS NULL OR orig.name_zh = '')
+					AND dup.name_zh IS NOT NULL
+					AND dup.name_zh <> '';
+
+				-- Delete duplicate categories that don't use Kickstarter numeric IDs
+				-- Original categories have short numeric IDs (1-999), duplicates have longer/encoded IDs
+				DELETE FROM categories
+				WHERE id IN (
+					SELECT c2.id
+					FROM categories c1
+					JOIN categories c2 ON c1.name = c2.name AND c1.id <> c2.id
+					WHERE LENGTH(c1.id) <= 3 AND c1.id ~ '^[0-9]+$'
+						AND (LENGTH(c2.id) > 3 OR c2.id !~ '^[0-9]+$')
+				);
+			END IF;
+		END
+		$$;
+	`).Error; err != nil {
+		log.Printf("DB init: category dedup warning: %v", err)
+	}
+
 	// NOW run AutoMigrate after all column renames are complete
 	if err := DB.AutoMigrate(
 		&model.Campaign{},

--- a/backend/internal/handler/campaigns.go
+++ b/backend/internal/handler/campaigns.go
@@ -117,7 +117,7 @@ func ListCampaigns(client *service.KickstarterScrapingService) gin.HandlerFunc {
 			gqlSort = "MAGIC"
 		}
 
-		result, err := client.Search("", categoryID, gqlSort, cursor, limit)
+		result, err := client.SearchWithState("", categoryID, gqlSort, cursor, limit, state)
 		if err != nil {
 			c.JSON(http.StatusInternalServerError, gin.H{"error": "database and API unavailable"})
 			return

--- a/backend/internal/handler/campaigns.go
+++ b/backend/internal/handler/campaigns.go
@@ -26,6 +26,7 @@ func ListCampaigns(client *service.KickstarterScrapingService) gin.HandlerFunc {
 		sort := c.DefaultQuery("sort", "trending")
 		categoryID := c.Query("category_id")
 		cursor := c.Query("cursor")
+		state := c.DefaultQuery("state", "live")
 		limit, _ := strconv.Atoi(c.DefaultQuery("limit", "20"))
 		if limit > 50 {
 			limit = 50
@@ -58,10 +59,12 @@ func ListCampaigns(client *service.KickstarterScrapingService) gin.HandlerFunc {
 			}
 
 			var campaigns []model.Campaign
-			// Filter: state='live' AND deadline >= NOW() to exclude expired campaigns
-			// Cron only upserts campaigns from discover pages (which only show live ones),
-			// but never marks rows as ended when they disappear/expire.
-			q := db.DB.Where("state = 'live' AND deadline >= ?", time.Now()).Offset(offset).Limit(limit + 1)
+			q := db.DB.Where("state = ?", state).Offset(offset).Limit(limit + 1)
+
+			// Only filter by deadline for live campaigns
+			if state == "live" {
+				q = q.Where("deadline >= ?", time.Now())
+			}
 
 			// Map sort to DB columns
 			switch sort {

--- a/backend/internal/handler/health.go
+++ b/backend/internal/handler/health.go
@@ -4,8 +4,23 @@ import (
 	"net/http"
 
 	"github.com/gin-gonic/gin"
+	"github.com/kickwatch/backend/internal/service"
 )
 
 func Health(c *gin.Context) {
 	c.JSON(http.StatusOK, gin.H{"status": "ok", "service": "kickwatch-api"})
+}
+
+func CronStatus(cronSvc *service.CronService) gin.HandlerFunc {
+	return func(c *gin.Context) {
+		status := gin.H{
+			"last_crawl_at":    nil,
+			"last_crawl_count": cronSvc.LastCrawlCount,
+			"last_crawl_error": cronSvc.LastCrawlError,
+		}
+		if !cronSvc.LastCrawlAt.IsZero() {
+			status["last_crawl_at"] = cronSvc.LastCrawlAt
+		}
+		c.JSON(http.StatusOK, status)
+	}
 }

--- a/backend/internal/service/cron.go
+++ b/backend/internal/service/cron.go
@@ -51,6 +51,8 @@ func (s *CronService) Start() {
 		log.Println("Cron: starting nightly crawl")
 		if err := s.RunCrawlNow(); err != nil {
 			log.Printf("Cron: crawl error: %v", err)
+			s.LastCrawlError = err.Error()
+			s.LastCrawlAt = time.Now()
 		}
 	})
 	s.scheduler.Start()

--- a/backend/internal/service/cron.go
+++ b/backend/internal/service/cron.go
@@ -31,6 +31,9 @@ type CronService struct {
 	apnsClient      *APNsClient
 	translator      *TranslatorService
 	scheduler       *cron.Cron
+	LastCrawlAt     time.Time
+	LastCrawlCount  int
+	LastCrawlError  string
 }
 
 func NewCronService(db *gorm.DB, scrapingService *KickstarterScrapingService, apns *APNsClient, translator *TranslatorService) *CronService {
@@ -79,8 +82,8 @@ func (s *CronService) Stop() {
 	s.scheduler.Stop()
 }
 
-// syncCategories upserts the canonical category list into the DB so that
-// clients and alert filters always see the current IDs and subcategories.
+// syncCategories upserts the canonical category list into the DB and
+// translates any categories missing Chinese translations.
 func (s *CronService) syncCategories() {
 	result := s.db.Clauses(clause.OnConflict{
 		Columns:   []clause.Column{{Name: "id"}},
@@ -90,6 +93,25 @@ func (s *CronService) syncCategories() {
 		log.Printf("Cron: category sync error: %v", result.Error)
 	} else {
 		log.Printf("Cron: synced %d categories", len(kickstarterCategories))
+	}
+
+	// Translate any categories missing name_zh
+	if s.translator != nil {
+		var allCats []model.Category
+		if err := s.db.Find(&allCats).Error; err != nil {
+			log.Printf("Cron: fetch categories for translation error: %v", err)
+			return
+		}
+		if err := s.translator.TranslateCategories(allCats); err != nil {
+			log.Printf("Cron: category translation error: %v", err)
+			return
+		}
+		// Update translated categories back to DB
+		for _, cat := range allCats {
+			if cat.NameZh != "" {
+				s.db.Model(&model.Category{}).Where("id = ?", cat.ID).Update("name_zh", cat.NameZh)
+			}
+		}
 	}
 }
 
@@ -170,6 +192,10 @@ func (s *CronService) RunCrawlNow() error {
 		}
 	}
 	log.Printf("Cron: crawl done, upserted %d campaigns", upserted)
+
+	s.LastCrawlAt = time.Now()
+	s.LastCrawlCount = upserted
+	s.LastCrawlError = ""
 
 	// Sanity check: a full crawl across all categories should always yield
 	// at least some campaigns. Zero almost certainly means a parse failure

--- a/backend/internal/service/kickstarter_scraping.go
+++ b/backend/internal/service/kickstarter_scraping.go
@@ -29,6 +29,10 @@ func NewKickstarterScrapingService(apiKey string, maxConcurrent int) *Kickstarte
 // Note: AI extraction was removed — Kickstarter embeds project data in [data-project]
 // HTML attributes, not text nodes, so ScrapingBee AI returns EMPTY_RESPONSE for that selector.
 func (s *KickstarterScrapingService) Search(term, categoryID, sort, cursor string, first int) (*SearchResult, error) {
+	return s.SearchWithState(term, categoryID, sort, cursor, first, "")
+}
+
+func (s *KickstarterScrapingService) SearchWithState(term, categoryID, sort, cursor string, first int, state string) (*SearchResult, error) {
 	ctx := context.Background()
 
 	// Parse page from cursor (cursor format: "page:N")
@@ -40,6 +44,9 @@ func (s *KickstarterScrapingService) Search(term, categoryID, sort, cursor strin
 	}
 
 	discoverURL := s.buildDiscoverURL(term, categoryID, sort, page)
+	if state != "" && state != "live" {
+		discoverURL += "&state=" + state
+	}
 
 	html, err := s.client.FetchHTMLInSession(ctx, discoverURL, 0)
 	if err != nil {

--- a/backend/internal/service/translator.go
+++ b/backend/internal/service/translator.go
@@ -188,6 +188,95 @@ func (t *TranslatorService) translateBatch(model *genai.GenerativeModel, campaig
 	return nil
 }
 
+// TranslateCategories translates category names that are missing Chinese translations.
+func (t *TranslatorService) TranslateCategories(categories []model.Category) error {
+	var untranslated []model.Category
+	for _, c := range categories {
+		if c.NameZh == "" {
+			untranslated = append(untranslated, c)
+		}
+	}
+	if len(untranslated) == 0 {
+		return nil
+	}
+
+	model := t.client.GenerativeModel("gemini-2.0-flash-001")
+	model.SetTemperature(0.3)
+
+	type catInput struct {
+		ID   string `json:"id"`
+		Name string `json:"name"`
+	}
+	type catOutput struct {
+		ID     string `json:"id"`
+		NameZh string `json:"name_zh"`
+	}
+
+	const batchSize = 20
+	for i := 0; i < len(untranslated); i += batchSize {
+		end := i + batchSize
+		if end > len(untranslated) {
+			end = len(untranslated)
+		}
+		batch := untranslated[i:end]
+
+		inputs := make([]catInput, len(batch))
+		for j, c := range batch {
+			inputs[j] = catInput{ID: c.ID, Name: c.Name}
+		}
+		inputJSON, _ := json.MarshalIndent(inputs, "", "  ")
+
+		prompt := fmt.Sprintf(`将以下 Kickstarter 分类名称翻译成中文。输出 JSON 数组，每个元素包含 id 和 name_zh。
+
+输入：
+%s
+
+直接输出 JSON 数组，不要有其他文字：`, string(inputJSON))
+
+		ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+		resp, err := model.GenerateContent(ctx, genai.Text(prompt))
+		cancel()
+		if err != nil {
+			log.Printf("Translator: category batch %d-%d error: %v", i, end-1, err)
+			continue
+		}
+
+		if len(resp.Candidates) == 0 || len(resp.Candidates[0].Content.Parts) == 0 {
+			continue
+		}
+
+		responseText := fmt.Sprintf("%v", resp.Candidates[0].Content.Parts[0])
+		responseText = strings.TrimSpace(responseText)
+		responseText = strings.TrimPrefix(responseText, "```json")
+		responseText = strings.TrimPrefix(responseText, "```")
+		responseText = strings.TrimSuffix(responseText, "```")
+		responseText = strings.TrimSpace(responseText)
+
+		var outputs []catOutput
+		if err := json.Unmarshal([]byte(responseText), &outputs); err != nil {
+			log.Printf("Translator: failed to parse category response: %v", err)
+			continue
+		}
+
+		idMap := make(map[string]string)
+		for _, out := range outputs {
+			idMap[out.ID] = out.NameZh
+		}
+
+		for j := range categories {
+			if zh, ok := idMap[categories[j].ID]; ok && zh != "" {
+				categories[j].NameZh = zh
+			}
+		}
+
+		log.Printf("Translator: translated %d category names", len(outputs))
+		if end < len(untranslated) {
+			time.Sleep(2 * time.Second)
+		}
+	}
+	return nil
+}
+
 // Close releases resources held by the translator.
 func (t *TranslatorService) Close() error {
 	if t.client != nil {


### PR DESCRIPTION
## Summary

Fixes four open issues in a single PR:

### #43 — State filter ignored in campaigns API
The `GET /api/campaigns?state=successful` endpoint hardcoded `state='live'` in the DB query. Now uses the `state` query parameter (defaults to `live`). Deadline filter only applies to live campaigns.

### #44 — Campaign snapshots stale (cron not running)
Root cause is infra (ECS `desired_count=0`). Added `GET /admin/cron-status` endpoint that exposes `last_crawl_at`, `last_crawl_count`, and `last_crawl_error` for observability. **Action needed**: set ECS `desired_count=1` for `kickwatch-api-dev`.

### #45 — Duplicate root categories
Added DB migration in `db.Init()` to merge `name_zh` from duplicate category rows into originals (matched by name), then delete non-canonical duplicates (identified by non-numeric IDs).

### #46 — Category Chinese translation coverage (13.2%)
Added `TranslateCategories()` method to the Vertex AI translator service. Called during cron `syncCategories()` to translate all categories missing `name_zh`. Batches of 20 with 2s rate limiting.

Fixes #43, Fixes #44, Fixes #45, Fixes #46

## Testing
- `go build ./...` passes
- `go test ./...` passes
- `go vet ./...` clean